### PR TITLE
Fix the 'Unresolved Symbols' error caused by commit 21e692b

### DIFF
--- a/build/miniblink/miniblink.vcxproj
+++ b/build/miniblink/miniblink.vcxproj
@@ -4582,6 +4582,7 @@
     <ClCompile Include="..\..\third_party\WebKit\Source\wtf\text\WTFStringUtil.cpp" />
     <ClCompile Include="..\..\ui\gfx\win\dpi.cc" />
     <ClCompile Include="..\..\wke\wke.cpp" />
+    <ClCompile Include="..\..\wke\wkeGlobalVar.cpp" />
     <ClCompile Include="..\..\wke\wkeJsBind.cpp" />
     <ClCompile Include="..\..\wke\wkeNetHook.cpp" />
     <ClCompile Include="..\..\wke\wkeString.cpp" />
@@ -8389,6 +8390,7 @@
     <ClInclude Include="..\..\ui\gfx\win\dpi.h" />
     <ClInclude Include="..\..\wke\wke.h" />
     <ClInclude Include="..\..\wke\wkedefine.h" />
+    <ClInclude Include="..\..\wke\wkeGlobalVar.h" />
     <ClInclude Include="..\..\wke\wkeJsBind.h" />
     <ClInclude Include="..\..\wke\wkeJsBindFreeTempObject.h" />
     <ClInclude Include="..\..\wke\wkeNetHook.h" />

--- a/build/miniblink/miniblink.vcxproj.filters
+++ b/build/miniblink/miniblink.vcxproj.filters
@@ -10131,6 +10131,9 @@
     <ClCompile Include="..\..\net\ActivatingObjCheck.cpp">
       <Filter>net</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\wke\wkeGlobalVar.cpp">
+      <Filter>wke</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\public\platform\modules\app_banner\WebAppBannerClient.h">
@@ -23013,9 +23016,6 @@
     <ClInclude Include="..\..\gen\blink\bindings\modules\v8\V8DataTransferItemPartial.h">
       <Filter>gen\blink\bindings\modules\v8</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\wke\wkeRecordExceptionInfo.h">
-      <Filter>wke</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\net\ActivatingObjCheck.h">
       <Filter>net</Filter>
     </ClInclude>
@@ -23023,6 +23023,9 @@
       <Filter>content\browser</Filter>
     </ClInclude>
     <ClInclude Include="..\..\wke\wkeUtil.h">
+      <Filter>wke</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\wke\wkeGlobalVar.h">
       <Filter>wke</Filter>
     </ClInclude>
   </ItemGroup>

--- a/net/WebURLLoaderManager.cpp
+++ b/net/WebURLLoaderManager.cpp
@@ -81,7 +81,9 @@
 
 #if (defined ENABLE_WKE) && (ENABLE_WKE == 1)
 #include "wke/wkeWebView.h"
-extern bool g_isDecodeUrlRequest;
+namespace wke {
+    extern bool g_isDecodeUrlRequest;
+}
 #endif
 #include "wtf/RefCountedLeakCounter.h"
 
@@ -1036,7 +1038,7 @@ int WebURLLoaderManager::addAsynchronousJob(WebURLLoaderInternal* job)
     OutputDebugStringW(outString.charactersWithNullTermination().data());
 #endif
 
-    if (g_isDecodeUrlRequest && !kurl.protocolIsData()) {
+    if (wke::g_isDecodeUrlRequest && !kurl.protocolIsData()) {
         url = blink::decodeURLEscapeSequences(url);
         job->firstRequest()->setURL((blink::KURL(blink::ParsedURLString, url)));
     }


### PR DESCRIPTION
1. The wke\wkeGlobalVar.cpp for global variables is not added into the VS2015 project files.  
2. The namespace is missing for g_isDecodeUrlRequest in WebURLLoaderManager.cpp file.