### PR TITLE
修复设置代理后 MemoryCache 异常的问题

### DIFF
--- a/net/WebURLLoaderInternal.h
+++ b/net/WebURLLoaderInternal.h
@@ -190,6 +190,7 @@ public:
     bool m_isBlackList;
     bool m_isDataUrl;
     bool m_isProxy;
+    bool m_isProxyConnect; // 是否使用代理的Connect请求
     bool m_isProxyHeadRequest;
     bool m_needParseMime; // 如果response为空的时候，是否需要在recv data的时候分析
 

--- a/net/WebURLLoaderManager.cpp
+++ b/net/WebURLLoaderManager.cpp
@@ -462,7 +462,7 @@ static size_t writeCallbackOnIoThread(void* ptr, size_t size, size_t nmemb, void
     // of html page even if it is a redirect that was handled internally
     // can be observed e.g. on gmail.com
     long httpCode = 0;
-    CURLcode err = curl_easy_getinfo(job->m_handle, !job->m_isProxy ? CURLINFO_RESPONSE_CODE : CURLINFO_HTTP_CONNECTCODE, &httpCode);
+    CURLcode err = curl_easy_getinfo(job->m_handle, !job->m_isProxyConnect ? CURLINFO_RESPONSE_CODE : CURLINFO_HTTP_CONNECTCODE, &httpCode);
     if (CURLE_OK == err && httpCode >= 300 && httpCode < 400)
         return totalSize;
 
@@ -1545,6 +1545,8 @@ void WebURLLoaderManager::initializeHandleOnIoThread(int jobId, InitializeHandle
 #if (defined ENABLE_WKE) && (ENABLE_WKE == 1)
     if (info->proxy.size()) {
         job->m_isProxy = true;
+        if(info->url.find("https") == 0)
+            job->m_isProxyConnect = true;
         curl_easy_setopt(job->m_handle, CURLOPT_PROXY, info->proxy.c_str());
         curl_easy_setopt(job->m_handle, CURLOPT_PROXYTYPE, info->proxyType);
     }  
@@ -1693,6 +1695,7 @@ WebURLLoaderInternal::WebURLLoaderInternal(WebURLLoaderImplCurl* loader, const W
     m_isBlackList = false;
     m_isDataUrl = false;
     m_isProxy = false;
+    m_isProxyConnect = false;
     m_isProxyHeadRequest = false;
     m_needParseMime = true;
     m_isHoldJobToAsynCommit = false;


### PR DESCRIPTION
https://github.com/weolar/miniblink49/issues/272
原因：只有在使用代理的 Connect 请求时才需要使用 CURLINFO_HTTP_CONNECTCODE 来获取返回码，而只有 HTTPS 请求才会使用 Connect