### PR TITLE
Fix: Potential Vulnerability in Cloned Function

### DIFF
--- a/third_party/ffmpeg/libavcodec/pictordec.c
+++ b/third_party/ffmpeg/libavcodec/pictordec.c
@@ -142,7 +142,7 @@ static int decode_frame(AVCodecContext *avctx,
 
     if (av_image_check_size(s->width, s->height, 0, avctx) < 0)
         return -1;
-    if (s->width != avctx->width && s->height != avctx->height) {
+    if (s->width != avctx->width || s->height != avctx->height) {
         ret = ff_set_dimensions(avctx, s->width, s->height);
         if (ret < 0)
             return ret;


### PR DESCRIPTION
**Description**
This PR fixes a security vulnerability in decode_frame() that was cloned from FFmpeg but did not receive the security patch. The original issue was reported and fixed under https://github.com/FFmpeg/FFmpeg/commit/8c2ea3030af7b40a3c4275696fb5c76cdb80950a.
This PR applies the same patch to eliminate the vulnerability.

**References**
https://nvd.nist.gov/vuln/detail/CVE-2017-7862
https://github.com/FFmpeg/FFmpeg/commit/8c2ea3030af7b40a3c4275696fb5c76cdb80950a
