### PR TITLE
third_party/ffmpeg/libavcodec/x86/mpegvideodsp.c: Fix signedness bug in need_emu

### DIFF
--- a/third_party/ffmpeg/libavcodec/x86/mpegvideodsp.c
+++ b/third_party/ffmpeg/libavcodec/x86/mpegvideodsp.c
@@ -53,8 +53,8 @@ static void gmc_mmx(uint8_t *dst, uint8_t *src,
     const int dyh = (dyy - (1 << (16 + shift))) * (h - 1);
     const int dxh = dxy * (h - 1);
     const int dyw = dyx * (w - 1);
-    int need_emu  =  (unsigned) ix >= width  - w ||
-                     (unsigned) iy >= height - h;
+    int need_emu  =  (unsigned) ix >= width  - w || width < w ||
+                     (unsigned) iy >= height - h || height < h;
 
     if ( // non-constant fullpel offset (3% of blocks)
         ((ox ^ (ox + dxw)) | (ox ^ (ox + dxh)) | (ox ^ (ox + dxw + dxh)) |


### PR DESCRIPTION
**Description**
This PR fixes a potential vulnerability in `gmc_mmx()` in mpegvideodsp.c that was cloned from FFmpeg but did not receive the security patch. The original issue was reported and fixed under https://github.com/FFmpeg/FFmpeg/commit/58cf31cee7a456057f337b3102a03206d833d5e8.
This PR applies the same patch to eliminate the vulnerability.

References
https://nvd.nist.gov/vuln/detail/CVE-2017-17081
https://github.com/FFmpeg/FFmpeg/commit/58cf31cee7a456057f337b3102a03206d833d5e8